### PR TITLE
Potential fix for code scanning alert no. 27: Bad HTML filtering regexp

### DIFF
--- a/apps/web/lib/speed-reader.ts
+++ b/apps/web/lib/speed-reader.ts
@@ -78,8 +78,8 @@ function decodeHtmlEntitiesFully(value: string) {
 function stripHtmlTags(value: string) {
   return value
     .replace(/<!--[\s\S]*?-->/g, " ")
-    .replace(/<script[\s\S]*?<\/script>/gi, " ")
-    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<script\b[\s\S]*?<\/script\b[^>]*>/gi, " ")
+    .replace(/<style\b[\s\S]*?<\/style\b[^>]*>/gi, " ")
     .replace(/<br\s*\/?>/gi, " ")
     .replace(
       /<\/?(p|div|li|h[1-6]|section|article|ul|ol|blockquote|pre|table|tr|td|th)\b[^>]*>/gi,


### PR DESCRIPTION
Potential fix for [https://github.com/nicholasgriffintn/website/security/code-scanning/27](https://github.com/nicholasgriffintn/website/security/code-scanning/27)

In general, the problem is that the script‑stripping regex assumes a strictly well‑formed `</script>` end tag. Browsers will close a `<script>` element on more permissive constructs like `</script >` or `</script foo="bar">`. To fix this, we should adjust the regex to allow optional whitespace and attributes between `</script` and the closing `>` so that any script block that the browser would treat as closed is also removed by this function.

The best targeted fix is to update the script and style removal patterns to tolerate such malformed end tags while keeping their current behavior otherwise. Specifically, we can change:
- `/\<script[\s\S]*?<\/script>/gi` to `/\<script\b[\s\S]*?<\/script\b[^>]*>/gi`
- `/\<style[\s\S]*?<\/style>/gi` to `/\<style\b[\s\S]*?<\/style\b[^>]*>/gi`

These adjusted patterns:
- Add `\b` after `script`/`style` to ensure whole tag names.
- For the closing tags, match `</script\b[^>]*>` and `</style\b[^>]*>` so that they accept additional whitespace/attributes and still terminate at `>`.

No new helper functions or non‑standard imports are needed; we only modify the literals in `stripHtmlTags` in `apps/web/lib/speed-reader.ts`, at lines 81–82.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
