### PR TITLE
Potential fix for code scanning alert no. 25: Incomplete multi-character sanitization

### DIFF
--- a/apps/blog-text-to-speech/src/utils.ts
+++ b/apps/blog-text-to-speech/src/utils.ts
@@ -119,7 +119,10 @@ function cleanInlineMarkdown(
   const supportedTags = getSupportedMarkupTags(profile, supportsBreakTags);
 
   if (supportedTags.length === 0) {
-    return value.replace(/<[^>]+>/g, "").trim();
+    return value
+      .replace(/<[^>]+>/g, "")
+      .replace(/[<>]/g, "")
+      .trim();
   }
 
   const tokens = new Map<string, string>();

--- a/apps/blog-text-to-speech/src/utils.ts
+++ b/apps/blog-text-to-speech/src/utils.ts
@@ -119,10 +119,7 @@ function cleanInlineMarkdown(
   const supportedTags = getSupportedMarkupTags(profile, supportsBreakTags);
 
   if (supportedTags.length === 0) {
-    return value
-      .replace(/<[^>]+>/g, "")
-      .replace(/[<>]/g, "")
-      .trim();
+    return value.replace(/[<>]/g, "").trim();
   }
 
   const tokens = new Map<string, string>();


### PR DESCRIPTION
Potential fix for [https://github.com/nicholasgriffintn/website/security/code-scanning/25](https://github.com/nicholasgriffintn/website/security/code-scanning/25)

General approach: avoid partial or ineffective stripping of HTML/markup-like constructs by ensuring that sanitization cannot reintroduce `<...>` sequences. Two robust patterns are: (1) repeatedly applying tag-removal until the string stabilizes, or (2) stripping all `<` and `>` characters when we intend to remove all markup anyway. In this function, in the `supportedTags.length === 0` branch, we want no tags at all, so removing `<` and `>` characters is safe and strictly stronger than removing just `<...>` patterns.

Best fix here: replace `value.replace(/<[^>]+>/g, "").trim();` with a two-step sanitization that first removes tag-like sequences, then strips any remaining literal `<` or `>` characters. This directly addresses CodeQL’s concern that the string may still contain `<script`, and it avoids repeated regex calls while preserving intent (no markup). We do not change behavior in the other branch that preserves whitelisted SSML tags.

Concretely:
- In `apps/blog-text-to-speech/src/utils.ts`, inside the function shown (the one that processes `line` and `profile` and uses `supportedTags`), update the `if (supportedTags.length === 0)` block at line 121–123.
- Change the `return value.replace(/<[^>]+>/g, "").trim();` line so that:
  - First, tag-like segments are removed with the existing regex.
  - Then any stray `<` or `>` are removed with `replace(/[<>]/g, "")`.
- No new imports or helpers are needed; we rely solely on native `String.prototype.replace`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
