### PR TITLE
Potential fix for code scanning alert no. 23: Double escaping or unescaping

### DIFF
--- a/apps/web/lib/markdown.ts
+++ b/apps/web/lib/markdown.ts
@@ -31,7 +31,7 @@ export function parseMarkdown(input: string, muted = false, classNames: { p?: st
   });
 
   // Escape HTML first to prevent XSS from externally-sourced content
-  let html = escapeHTML(input.replace(/\\\\/g, "\\").replace(/\\n/g, "\n"))
+  let html = escapeHTML(input)
     // Replace known XML-like tags after escaping (they are now escaped entities)
     .replace(/&lt;summary&gt;/g, "**Summary:** ")
     .replace(/&lt;\/summary&gt;/g, "")


### PR DESCRIPTION
Potential fix for [https://github.com/nicholasgriffintn/website/security/code-scanning/23](https://github.com/nicholasgriffintn/website/security/code-scanning/23)

In general, to avoid double unescaping/escaping, avoid running ad‑hoc unescape logic on inputs whose escape status is unknown, and prefer to treat incoming text as already “literal” unless you *know* it is still full of escape sequences. In this function, the problematic part is the pre-processing of backslashes and `\n` sequences before HTML-escaping.

The minimal and safest fix, without changing the intended HTML output for “normal” user inputs, is:

- Remove the manual unescaping `input.replace(/\\\\/g, "\\").replace(/\\n/g, "\n")`.
- Feed `input` directly into `escapeHTML`.
- Keep all the subsequent tag-entity replacements unchanged.

This change:
- Eliminates the potential for double-unescaping `\\` and `\n`.
- Does not weaken XSS protections; in fact, it is safer since we are no longer transforming escape sequences before escaping HTML.
- May slightly change behavior only for inputs that were *deliberately* encoded with extra backslashes (e.g. trying to embed literal `\n` sequences). In those cases, the function will now display the backslash characters literally instead of converting them into newlines, which is typically acceptable and safer.

Concretely, in `apps/web/lib/markdown.ts`, edit the line where `html` is initialized (line 34) to remove the `.replace(/\\\\/g, "\\").replace(/\\n/g, "\n")` call and pass `input` directly to `escapeHTML`.

No new methods or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
