### PR TITLE
Potential fix for code scanning alert no. 16: Incomplete URL substring sanitization

### DIFF
--- a/apps/web/lib/returnImageFormattingUrl.ts
+++ b/apps/web/lib/returnImageFormattingUrl.ts
@@ -1,7 +1,7 @@
 const BASE_URL = "https://images.nicholasgriffin.dev";
 
 const ReturnImageFormattingUrl = (url: string) => {
-  if (url.includes("https://cdn.nicholasgriffin.dev/")) {
+  if (url.startsWith("https://cdn.nicholasgriffin.dev/")) {
     const noCDNURL = url.replace("https://cdn.nicholasgriffin.dev/", "");
 
     return `${BASE_URL}/resize/?image=${noCDNURL}`;


### PR DESCRIPTION
Potential fix for [https://github.com/nicholasgriffintn/website/security/code-scanning/16](https://github.com/nicholasgriffintn/website/security/code-scanning/16)

In general, the issue comes from using a substring match (`includes`) instead of a stricter check on the URL structure or prefix. To fix it safely, we should ensure that the code only rewrites URLs that are actually from `https://cdn.nicholasgriffin.dev/`, not any string that merely contains that substring. The two straightforward approaches are: (1) parse the URL with the standard `URL` class and verify the `origin` or `hostname` and `protocol`, or (2) if we know the value is a simple absolute string, replace `includes` with `startsWith` on the exact prefix we expect. Given the current code, which immediately does `url.replace("https://cdn.nicholasgriffin.dev/", "")`, the semantics clearly assume the CDN prefix is at the beginning of the string; using `startsWith` preserves intended behavior while eliminating the substring issue, without introducing any new dependencies.

Concretely, in `apps/web/lib/returnImageFormattingUrl.ts`, change the condition on line 4 from `url.includes("https://cdn.nicholasgriffin.dev/")` to `url.startsWith("https://cdn.nicholasgriffin.dev/")`. The rest of the function can stay as-is, because `replace` with that exact string will already only remove the first occurrence, which is at the start when `startsWith` holds. This change requires no new imports or helpers and preserves existing functionality for valid CDN URLs while avoiding matches where the CDN URL appears later in the string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
