### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -3,6 +3,9 @@ name: Deploy to Production
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   Deploy-Production:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nicholasgriffintn/website/security/code-scanning/21](https://github.com/nicholasgriffintn/website/security/code-scanning/21)

In general, the fix is to add an explicit `permissions` block specifying the minimal required permissions for the `GITHUB_TOKEN`. This can be done either at the workflow root (applies to all jobs without their own `permissions`) or on the specific job. Since this workflow has only one job and does not show any need for write access, we can safely restrict `contents` to `read`, which also matches the CodeQL suggestion.

The best, least-invasive fix without changing functionality is to add a `permissions:` block at the top level of the workflow, just under the `on:` block (or just under `name:`), setting `contents: read`. This will apply to the `Deploy-Production` job and avoid relying on repository/organization defaults. No imports or other structural changes are required since this is just YAML configuration.

Concretely, in `.github/workflows/production.yaml`, insert:

```yaml
permissions:
  contents: read
```

near the top of the file (e.g., between the `on:` section and `jobs:`), keeping indentation consistent. No other lines or behavior need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
