### PR TITLE
Potential fix for code scanning alert no. 20: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,5 +1,8 @@
 name: Deploy to Preview
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
Potential fix for [https://github.com/nicholasgriffintn/website/security/code-scanning/20](https://github.com/nicholasgriffintn/website/security/code-scanning/20)

In general, the problem is fixed by explicitly declaring a `permissions` block either at the workflow root (applying to all jobs) or inside the specific job, granting only the minimal scopes needed (typically `contents: read` for workflows that just check out code). This ensures the `GITHUB_TOKEN` does not inherit potentially broad repository defaults.

For this workflow, the job only checks out code and runs a deployment using external Cloudflare credentials, so it should only need read access to the repository contents. The best minimal, non-breaking fix is to add `permissions: contents: read` at the workflow root (right after `name:` and before `on:`), which will apply to all jobs in this file, including `Deploy-Preview`. No additional imports or definitions are needed because this is purely a YAML configuration change and does not alter any step behavior.

Concretely, in `.github/workflows/preview.yaml`, insert:

```yaml
permissions:
  contents: read
```

between the existing `name: Deploy to Preview` line and the `on:` block. This documents and constrains the token permissions while preserving all existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
